### PR TITLE
Small fix

### DIFF
--- a/moneymanagementtool.c
+++ b/moneymanagementtool.c
@@ -143,11 +143,11 @@ void ptgcheck(char name[][100], int total2, int n, int total, int paid[])
         {
             paid[i] = 0;
             printf("%s's percentage share is %d \n", name[i], paid[i]);
-            printf("%s's \% share amount is %d\n", name[i], (paid[i] * total2) / 100);
+            printf("%s's %% share amount is %d\n", name[i], (paid[i] * total2) / 100);
         }
         paid[n - 1] = total - sum;
         printf("%s's percentage share is %d\n", name[n - 1], paid[n - 1]);
-        printf("%s's \% share amount is %d\n", name[n - 1], (paid[n - 1] * total2) / 100);
+        printf("%s's %% share amount is %d\n", name[n - 1], (paid[n - 1] * total2) / 100);
     }
 }
 


### PR DESCRIPTION
**Error:**

The error is due to incorrect usage of the escape character `%` in the printf format strings.

**Fix:**

Replace `\%` with `%%` in the printf format strings to correctly escape the `%` character.

**Corrected Code:**

_Lines 140  - 151_

```c
if (x > 0)
    {
        for (i = x; i < n - 1; i++)
        {
            paid[i] = 0;
            printf("%s's percentage share is %d \n", name[i], paid[i]);
            printf("%s's %% share amount is %d\n", name[i], (paid[i] * total2) / 100);
        }
        paid[n - 1] = total - sum;
        printf("%s's percentage share is %d\n", name[n - 1], paid[n - 1]);
        printf("%s's %% share amount is %d\n", name[n - 1], (paid[n - 1] * total2) / 100);
    }
```

**Short Description of the Fix:**

In C, `%` is a special character used to introduce format specifiers (like `%d` for integers). To print a literal `%` character, it needs to be escaped as `%%`. The fix replaces incorrect `\%` with `%%` to ensure the printf statements format correctly without errors.

**Testing:**

Ensured that the program compiles correctly.